### PR TITLE
Fix PdfPig.Rendering.Skia #77

### DIFF
--- a/UglyToad.PdfPig.Filters.Dct.JpegLibrary/Jpeg/JpegReader.cs
+++ b/UglyToad.PdfPig.Filters.Dct.JpegLibrary/Jpeg/JpegReader.cs
@@ -170,7 +170,7 @@ namespace UglyToad.PdfPig.Filters.Dct.JpegLibrary.Jpeg
                 length = default;
                 return false;
             }
-            length = (ushort)(buffer[0] << 8 | buffer[1] - 2);
+            length = (ushort)((buffer[0] << 8 | buffer[1]) - 2);
             _data = _data.Slice(2);
             return true;
         }
@@ -189,7 +189,7 @@ namespace UglyToad.PdfPig.Filters.Dct.JpegLibrary.Jpeg
                 length = default;
                 return false;
             }
-            length = (ushort)(buffer[0] << 8 | buffer[1] - 2);
+            length = (ushort)((buffer[0] << 8 | buffer[1]) - 2);
             return true;
         }
 

--- a/UglyToad.PdfPig.Filters.Dct.JpegLibrary/UglyToad.PdfPig.Filters.Dct.JpegLibrary.csproj
+++ b/UglyToad.PdfPig.Filters.Dct.JpegLibrary/UglyToad.PdfPig.Filters.Dct.JpegLibrary.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFrameworks>netstandard2.0;net462;net471;net6.0;net8.0</TargetFrameworks>
 		<LangVersion>12</LangVersion>
-		<Version>0.1.12.1</Version>
+		<Version>0.1.12.2</Version>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>


### PR DESCRIPTION
Both TryReadLength (line 173) and TryPeekLength (line 192) had the same bug — both are fixed.

Root cause summary:
- JPEG length fields are big-endian 16-bit values that include the 2 bytes of the field itself
- The decoder subtracts 2 to get the actual data bytes to skip
- Due to | vs - precedence, only the low byte had 2 subtracted, leaving the high bits from buffer[1] - 2 (which underflows to 0xFFFFFFFE)
OR'd into the result