### PR TITLE
Update PdfPig to 0.1.14 and add net9.0 target

### DIFF
--- a/UglyToad.PdfPig.Filters.Dct.JpegLibrary/UglyToad.PdfPig.Filters.Dct.JpegLibrary.csproj
+++ b/UglyToad.PdfPig.Filters.Dct.JpegLibrary/UglyToad.PdfPig.Filters.Dct.JpegLibrary.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;net462;net471;net6.0;net8.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net462;net471;net6.0;net8.0;net9.0</TargetFrameworks>
 		<LangVersion>12</LangVersion>
-		<Version>0.1.12.2</Version>
+		<Version>0.1.14.0</Version>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
@@ -13,7 +13,7 @@
 		<IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsAotCompatible>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(TargetFramework)'!='net8.0'">
+	<PropertyGroup Condition="'$(TargetFramework)'!='net8.0' AND '$(TargetFramework)'!='net9.0'">
 		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
 	</PropertyGroup>
 
@@ -63,7 +63,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="PdfPig" Version="0.1.12" />
+		<PackageReference Include="PdfPig" Version="0.1.14" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

- Bump `PdfPig` dependency from `0.1.12` to `0.1.14`
- Bump package version to `0.1.14.0`
- Add `net9.0` target framework to match PdfPig
- Exclude `net9.0` from `AllowUnsafeBlocks` (AOT compatibility, same as `net8.0`)

## Motivation

On .NET Framework, the CLR enforces strict version matching for strong-named assemblies.
The previous package baked a hard reference to `UglyToad.PdfPig, Version=0.1.12.0`,
causing load failures when consumers upgrade to PdfPig >= 0.1.13:

> Could not load file or assembly 'UglyToad.PdfPig, Version=0.1.12.0, Culture=neutral, PublicKeyToken=...'

Closes #5